### PR TITLE
Adding code coverage to travis.yml 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,7 @@ install:
 script:
   - python -m pytest tests/
   - pylint --fail-under=8 dsm/
+
+#command to track code coverage
+after_success:
+  - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This line of code will allow travis to update the code coverage percentage and display it on the codecov badge each time a pull request is merged with the main repo.